### PR TITLE
Update Python version to 3.8 in helm-lint.yaml

### DIFF
--- a/ .github/workflows/helm-lint.yaml
+++ b/ .github/workflows/helm-lint.yaml
@@ -1,0 +1,45 @@
+name: Helm Lint
+
+on: pull_request
+
+jobs:
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.8.1
+
+      # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
+      # yamllint (https://github.com/adrienverge/yamllint) which require Python
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.8
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ctconfig.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config ctconfig.yaml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.12.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --config ctconfig.yaml


### PR DESCRIPTION
Python 3.7 is not supported on GitHub Actions ubuntu-latest runner: actions/setup-python#962

Python 3.7 has reached EOL more than 1 year ago anyway, so not worth the effort supporting it.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/samanhappy/easeprobe/pull/16?shareId=4c51888d-0c6c-41fe-851d-98126038a35e).